### PR TITLE
Breaking feature: remove duplicate host from url

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ kubectl -n justice-archiver-dev
 
 # set some vars, gets the first available pod (only one in our case)
 K8S_NSP="justice-archiver-dev"; \
-K8S_POD=$(kubectl -n ${K8S_NSP} get pod -l app=${K8S_NSP} -o jsonpath="{.items[0].metadata.name}"); \
+K8S_POD=$(kubectl -n ${K8S_NSP} get pod -l app=${K8S_NSP} -o jsonpath="{.items[0].metadata.name}");
 ```
 
 After setting the above variables (`copy -> paste -> execute`) the following blocks of commands will work using `copy -> paste -> execute` too.

--- a/conf/generate-index.sh
+++ b/conf/generate-index.sh
@@ -68,11 +68,11 @@ while IFS= read -r archive_host; do
   rm "$DOMAIN_ARCHIVES_TEMP"
 
   ## Loops over each archive entry, creating an anchor link to each one.
-  while IFS= read -r archive_link; do
-    readable_date=$(date -d "${archive_link::-6}" +"%A, %d %B %Y")
+  while IFS= read -r archive_date; do
+    readable_date=$(date -d "${archive_date::-6}" +"%A, %d %B %Y")
     {
       echo '<li class="list-group-item">'
-      echo "<a href=\"${archive_host}${archive_link}${archive_host}index.html\" target=\"_blank\">$readable_date</a>"
+      echo "<a href=\"${archive_host}${archive_date}index-2.html\" target=\"_blank\">$readable_date</a>"
       echo '</li>'
     } >> "$OUTPUT"
   done < "$DOMAIN_ARCHIVES"

--- a/conf/node/process.js
+++ b/conf/node/process.js
@@ -102,8 +102,8 @@ async function spider(body) {
     settings = [
         '-s0', // never follow robots.txt and meta robots tags: https://www.mankier.com/1/httrack#-sN
         '-%k', // keep-alive if possible https://www.mankier.com/1/httrack#-%25k
-        //'-I0', // don't make an index page https://www.mankier.com/1/httrack#-I
-        //'-N100', // create without host directory https://www.mankier.com/1/httrack#-N100
+        '-I0', // don't make an index page https://www.mankier.com/1/httrack#-I
+        '-N100', // create without host directory https://www.mankier.com/1/httrack#-N100
         '-V', // execute system command after each file: https://www.mankier.com/1/httrack#-V
         '"sed -i \'s/ id="popular-wrapper"//g\' \$0"',
         '-O', // path for snapshot/logfiles+cache: https://www.mankier.com/1/httrack#-O


### PR DESCRIPTION
This is an aesthetic update to clean the resulting URL in our CloudFront distribution. 

**From:**
![Screenshot 2023-10-31 at 11 22 00](https://github.com/ministryofjustice/justice-website-archive/assets/47327051/a951b559-0987-4082-a4e4-0c15ac0be2a7)

**To:**
![Screenshot 2023-10-31 at 11 22 32](https://github.com/ministryofjustice/justice-website-archive/assets/47327051/3bfe9f23-2686-45f5-a7ed-b73d1528cf75)

### Breaking feature
When this is deployed, the index page will be generated. The result will invalidate all previous archive links on the index page. The URL will redirect the user to the incorrect place.

Once we have a successful archive, we should remove the invalid links. This can be done by executing the following commands in a running pod:

Exec into a running pod
```bash
K8S_NSP="justice-archiver-dev"; \
K8S_POD=$(kubectl -n ${K8S_NSP} get pod -l app=${K8S_NSP} -o jsonpath="{.items[0].metadata.name}"); \
kubectl exec -it ${K8S_POD} -n ${K8S_NSP} -- bash
```

Next, inside the pod, get all the archived dates and make a note of the ones that are failing:
```bash
aws s3 ls s3://${S3_BUCKET_NAME}/www.justice.gov.uk/
```

Next, delete failing links one by one. Change ARCHIVE_DATE accordingly:
```bash
ARCHIVE_DATE="2023-10-24-18-03" \
aws s3 rm s3://${S3_BUCKET_NAME}/www.justice.gov.uk/${ARCHIVE_DATE}/ --recursive
```
